### PR TITLE
Fixed issue with 'Open Code Chest' link on a sub site redirecting back to the main site.

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -657,7 +657,7 @@ EOT;
 							'</b>',
 							__( 'Code Chest is now managing your existing Custom JavaScript scripts. You can safely deactivate the Custom JavaScript plugin immediately.', 'gf-code-chest' ),
 							'</div>',
-							"<a href=\"{$url_path}?subview=gf-code-chest&page=gf_edit_forms&id={$form_id}&view=settings\" class=\"gform-button gform-button--white\">",
+							'<a href="' . admin_url( "admin.php?subview=gf-code-chest&page=gf_edit_forms&id={$form_id}&view=settings" ) . '" class="gform-button gform-button--white">',
 							__( 'Open Code Chest', 'gf-code-chest' ),
 							'</a>',
 							'</div>',

--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -648,8 +648,7 @@ EOT;
 					'name'     => 'code_chest_js',
 					'type'     => 'editor_js',
 					'callback' => function ( $setting ) use ( $form ) {
-						$form_id  = $form['id'];
-						$url_path = parse_url( RGFormsModel::get_current_page_url(), PHP_URL_PATH );
+						$form_id = $form['id'];
 						$markup_pieces = array(
 							'<div id="gform_setting_code_chest_js_overridden_warning" class="gform-settings-field gform-settings-field__html">',
 							'<div class="gform-settings-field"><b>',

--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -648,7 +648,8 @@ EOT;
 					'name'     => 'code_chest_js',
 					'type'     => 'editor_js',
 					'callback' => function ( $setting ) use ( $form ) {
-						$form_id = $form['id'];
+						$form_id  = $form['id'];
+						$url_path = parse_url( RGFormsModel::get_current_page_url(), PHP_URL_PATH );
 						$markup_pieces = array(
 							'<div id="gform_setting_code_chest_js_overridden_warning" class="gform-settings-field gform-settings-field__html">',
 							'<div class="gform-settings-field"><b>',
@@ -656,7 +657,7 @@ EOT;
 							'</b>',
 							__( 'Code Chest is now managing your existing Custom JavaScript scripts. You can safely deactivate the Custom JavaScript plugin immediately.', 'gf-code-chest' ),
 							'</div>',
-							"<a href=\"/wp-admin/admin.php?subview=gf-code-chest&page=gf_edit_forms&id={$form_id}&view=settings\" class=\"gform-button gform-button--white\">",
+							"<a href=\"{$url_path}?subview=gf-code-chest&page=gf_edit_forms&id={$form_id}&view=settings\" class=\"gform-button gform-button--white\">",
 							__( 'Open Code Chest', 'gf-code-chest' ),
 							'</a>',
 							'</div>',


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2530550446/62739?folderId=7098280

## Summary

Open Code Chest link on the subsite in multi-site installation opens to the main site with a form of the same ID.

The issue and the fix for it:
https://www.loom.com/share/690e1c10afd148bdb20d76d1d8a9af7d

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.