### PR TITLE
Fixed issue where PHP error would occur if a form without custom code was duplicated.

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -630,9 +630,12 @@ EOT;
 
 	public function duplicate_form_feeds( $form_id, $new_form_id ) {
 		$src_feeds = $this->get_feeds( $form_id );
-		$copy_feed = $src_feeds[0];
 
-		GFAPI::add_feed( $new_form_id, $copy_feed['meta'], $this->get_slug() );
+		if ( count( $src_feeds ) > 0 ) {
+			$copy_feed = $src_feeds[0];
+
+			GFAPI::add_feed( $new_form_id, $copy_feed['meta'], $this->get_slug() );
+		}
 	}
 
 	public function replace_custom_js_setting( $form_settings, $form ) {


### PR DESCRIPTION
# Summary

There was not check for an empty Code Chest feed array upon form duplication. If this array was empty, then a PHP error would occur as there is no `0th` element in the array.

