### PR TITLE
Fixed an issue where css comment is parsed as a css rule

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -679,7 +679,7 @@ EOT;
 		 * Find all CSS selectors, but ignore all `@` rules such as @font-face, @media, etc. as they are
 		 * defined globally and not can't be scoped to a certion "parent" selector.
 		 */
-		return preg_replace_callback('/^\s*(?!@)([^\r\n,{}]+)(,(?=[^}]*{)|\s*{)/m', function( $matches ) use ( $prefix ) {
+		return preg_replace_callback('/^\s*(?!@)([^\r\n,{}\/]+)(,(?=[^}]*{)|\s*{)/m', function( $matches ) use ( $prefix ) {
 			return $prefix . ' ' . trim( $matches[1] ) . $matches[2];
 		}, $css);
 	}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2544175554/63516

## Summary
When the character `,`  is used in CSS comment. The CSS comment is parsed as a CSS rule, hence the issue. This PR should fix the issue.