### PR TITLE
Added fix for filter

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -404,10 +404,10 @@ class GWiz_GF_Code_Chest extends GFFeedAddOn {
 		}
 
 		if ( ! empty( $custom_css ) ) {
-			return sprintf( '<style>%s</style>', $custom_css );
+			return $form_string . sprintf( '<style>%s</style>', $custom_css );
 		}
 
-		return '';
+		return $form_string;
 	}
 
 	public function is_applicable_form( $form ) {


### PR DESCRIPTION
I noticed while using this plug-in that we had some issues with the `gform_form_after_open` filter. It does not keep the other filters in mind.

For my scenario, I had to create another plug-in that added an extra script tag with some JSON in it that can be used with some JavaScript, however the JSON I added in my dev environment was not visible in production. When looking at the code, I see that the original value is not used, just the new Code Chest code is added. With this fix, the Code Chest code is added to the value that other plug-ins already provide here.