### PR TITLE
Fixed issue with `gform_post_save_feed_settings` hook callback that potentially breaks othe

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -268,6 +268,10 @@ class GWiz_GF_Code_Chest extends GFFeedAddOn {
 	}
 
 	public function save_code_chest_settings( $feed_id, $form_id, $settings, $feed_addon_instance ) {
+		if ( ! ( $feed_addon_instance instanceof GWiz_GF_Code_Chest ) ) {
+			return;
+		}
+
 		/**
 		 * Note that this must be handled manually as we (almost) completelty override the
 		 * settings form markup which apparently prevents GF from saving the settings.


### PR DESCRIPTION
# Summary

The callback for `gform_post_save_feed_settings` was running no matter which plugin class instance was gettig passed. This could cause issues with custom settings in other plugins for the given feed from other plugins.

Specifically, I was running into issues with this overwriting custom feed settings that GCN was saving.

