### PR TITLE
Added lint warning for `gform_post_render` hooks on AJAX enabled forms.

### DIFF
--- a/assets/js/code-mirror-custom-linter.js
+++ b/assets/js/code-mirror-custom-linter.js
@@ -1,0 +1,55 @@
+/**
+ * Adds a custom Linter to CodeMirror to warn users when using the gform_post_render hooks on AJAX enabled forms.
+ * This is because doing so can result in the hook callbacks being registered multiple times.
+ */
+
+(function() {
+    if (typeof window.editor_settings !== 'undefined') {
+        const originalInitialize = wp.codeEditor.initialize;
+    
+        wp.codeEditor.initialize = function(textarea, settings) {
+            const editor = originalInitialize(textarea, settings);
+            const customLinter = createCustomLinter(wp.CodeMirror);
+
+            editor.codemirror.setOption('lint', function(text, options) {
+                const defaultLintAnnotations = wp.CodeMirror.lint.javascript(text, options);
+
+                return defaultLintAnnotations.concat(customLinter(text));
+            });
+
+            return editor;
+        };
+    }
+
+    function createCustomLinter(CodeMirror) {
+        return function customLinter(text) {
+            const warnings = [];
+            const regex = new RegExp(/gform_post_render|gform\/postRender|gform\/post_render/, 'g');
+            let match;
+  
+            while ((match = regex.exec(text)) !== null) {
+                const matchedString = match[0];
+
+                warnings.push({
+                    from: CodeMirror.Pos(
+                        text.substr(0, match.index)
+                            .split('\n')
+                            .length - 1,
+                        match.index - text.lastIndexOf('\n', match.index - 1) - 1
+                    ),
+                    to: CodeMirror.Pos(
+                        text.substr(0, regex.lastIndex)
+                            .split('\n')
+                            .length - 1,
+                        regex.lastIndex - text.lastIndexOf('\n', regex.lastIndex - 1) - 1
+                    ),
+                    message: `'${matchedString}' should not be used on AJAX enabled forms. Doing so can result in the hook callback being registered multiple times.`,
+                    severity: 'warning'
+                });
+            }
+
+            return warnings;
+        }
+
+    }
+})();

--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -255,6 +255,14 @@ class GWiz_GF_Code_Chest extends GFFeedAddOn {
 
 		wp_enqueue_script( 'wp-theme-plugin-editor' );
 		wp_enqueue_style( 'wp-codemirror' );
+
+		wp_enqueue_script(
+			'gf-code-chest-custom-linter',
+			$this->get_base_url() . '/assets/js/code-mirror-custom-linter.js',
+			array( 'wp-theme-plugin-editor' ),
+			$this->_version,
+			true
+		);
 	}
 
 	public function noconflict_scripts( $scripts = array() ) {


### PR DESCRIPTION
# Context

Slack: https://gravitywiz.slack.com/archives/C04PLMYN38W/p1736521082881049

Pertinent information:

> we had a report of an issue with gform/postRender, the code was running an increasing number of times with each next,
> previous, validation error redisplay that occurred
>
> code chest is registering the snippets as form init scripts which adds them via  gform_post_render, so each time that fires > it adds the listeners for the events from the code snippets again

# Summary

Using `gform_post_render`, `gform/postRender` or `gform/post_render` on AJAX enabled forms can be problematic as the hook callbacks can be registered multiple times. (See above details)

This adds a lint warning to the JavaScript editor when these strings are detected.

![image](https://github.com/user-attachments/assets/98e3a0e5-2f6d-4eb9-8de7-afe115378033)
