### PR TITLE
Added `gfcc_updater_cache_ttl` for adjusting the Github updater cache TTL.

### DIFF
--- a/class-gwiz-gf-code-chest.php
+++ b/class-gwiz-gf-code-chest.php
@@ -114,6 +114,8 @@ class GWiz_GF_Code_Chest extends GFFeedAddOn {
 	public function pre_init() {
 		parent::pre_init();
 
+		add_filter( 'expiration_of_transient_wp_github_plugin_updater_gf-code-chest/gf-code-chest.php', array( $this, 'filter_updater_cache_ttl' ), 10, 3 );
+
 		$this->init_auto_updater();
 
 		/**
@@ -121,6 +123,29 @@ class GWiz_GF_Code_Chest extends GFFeedAddOn {
 		 */
 		add_filter( 'gform_export_form', array( $this, 'export_feeds_with_form' ) );
 		add_action( 'gform_forms_post_import', array( $this, 'import_feeds_with_form' ) );
+	}
+
+	/**
+	 * Filter the updater release metadata cache TTL.
+	 *
+	 * Defaults to the bundled updater value, unless overridden
+	 * with the `gfcc_updater_cache_ttl` filter.
+	 *
+	 * @param int    $expiration Existing transient expiration in seconds.
+	 * @param mixed  $value      Transient value.
+	 * @param string $transient  Transient name.
+	 *
+	 * @return int
+	 */
+	public function filter_updater_cache_ttl( $expiration, $value, $transient ) {
+		$ttl = (int) apply_filters(
+			'gfcc_updater_cache_ttl',
+			$expiration,
+			$value,
+			$transient
+		);
+
+		return $ttl;
 	}
 
 	/**


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3248978245/98934?viewId=3808239

## Summary

This PR adds a new filter, `gfcc_updater_cache_ttl`, that allows users to override the default 5-minute GitHub updater release metadata cache TTL without editing the bundled updater library.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.